### PR TITLE
Fix for NoneType error when post_data had no params

### DIFF
--- a/har2grinder.py
+++ b/har2grinder.py
@@ -43,8 +43,9 @@ def prepare_entry_request_call(entry):
     post_data = request.get('postData')
     if post_data:
         param_code = ''
-        for parameter in post_data.get('params'):
-            param_code += "            NVPair('%s', '%s'),\n" % (parameter.get('name'), parameter.get('value'))
+        if post_data.get('params'):
+            for parameter in post_data.get('params'):
+                param_code += "            NVPair('%s', '%s'),\n" % (parameter.get('name'), parameter.get('value'))
 
         param_code = param_code[12:-1]
         request_call = "        request%i.%s('%s', (%s))\n" % (test_number, method, grinder_path, param_code)


### PR DESCRIPTION
When post_data had no params, har2grinder would fail with the following stack trace:

Traceback (most recent call last):
  File "har2grinder.py", line 202, in <module>
    main()
  File "har2grinder.py", line 138, in main
    page['grinder']['function_code'] += prepare_entry_request_call(entry)
  File "har2grinder.py", line 46, in prepare_entry_request_call
    for parameter in post_data.get('params'):
TypeError: 'NoneType' object is not iterable
